### PR TITLE
Fix to allow build pack to work with heroku

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,3 +21,5 @@ write_profile() {
 
 create_env
 write_profile
+
+exit 0


### PR DESCRIPTION
Return exit 0 from compile script

Return a complete status allows herokus first class support for multiple
buildpacks to use this buildpack successfully
